### PR TITLE
Added missing QDataStream #include 

### DIFF
--- a/spl/DcSoftwareUpdate.cpp
+++ b/spl/DcSoftwareUpdate.cpp
@@ -24,6 +24,7 @@
 #include <QRegExp>
 #include "cmn/DcLog.h"
 #include <QApplication>
+#include <QDataStream>
 
 const char* DcSoftwareUpdate::kRedirectFileUrl = "http://www.strymon.net/upd_spl.bin";
 


### PR DESCRIPTION
Project does not compile on VS2013/Qt5.5:

`1>------ Rebuild All started: Project: dcmidi, Configuration: Debug Win32 ------
2>------ Rebuild All started: Project: spl, Configuration: Debug Win32 ------
2>DcSoftwareUpdate.cpp(285): error C2079: 'in' uses undefined class 'QDataStream'
2>DcSoftwareUpdate.cpp(285): error C2440: 'initializing' : cannot convert from 'QFile *' to 'int'
2>          There is no context in which this conversion is possible
2>DcSoftwareUpdate.cpp(288): error C2248: 'QByteArray::operator QNoImplicitBoolCast' : cannot access private member declared in class 'QByteArray'
2>          C:\Qt\5.5\msvc2013\include\QtCore/qbytearray.h(433) : see declaration of 'QByteArray::operator QNoImplicitBoolCast'
2>          C:\Qt\5.5\msvc2013\include\QtCore/qbytearray.h(160) : see declaration of 'QByteArray'
2>          C:\Qt\5.5\msvc2013\include\QtCore/qbytearray.h(433) : see declaration of 'QByteArray::operator QNoImplicitBoolCast'
2>          C:\Qt\5.5\msvc2013\include\QtCore/qbytearray.h(160) : see declaration of 'QByteArray'
2>DcSoftwareUpdate.cpp(288): warning C4552: '>>' : operator has no effect; expected operator with side-effect`

Solution: add `#include <QDataStream>` to `DcSoftwareUpdate.cpp`.