### PR TITLE
Corrected issue when MIDI adapter name contained more occurrences of IDX

### DIFF
--- a/lib/DcMidi/DcMidi.cpp
+++ b/lib/DcMidi/DcMidi.cpp
@@ -118,8 +118,12 @@ void DcMidi::buildPortNameList(RtMidi* pRtMidi)
             portName = filterPortName(portName);
 #endif
         
-            portName = portName.remove(QString::number(idx)).trimmed();
-            _portNameIndexHash.insert(portName,idx);
+            QString idxStr = QString::number(idx);
+            if (portName.endsWith(idxStr))
+            {
+                portName.chop(idxStr.length());
+            }
+            _portNameIndexHash.insert(portName.trimmed(), idx);
     }
 }
 


### PR DESCRIPTION
The first (`idx`=0) MIDI-in adapter on my PC is `EMU 0404 | USB` and `MiniInWinMM::getPortName` returns it as `EMU 0404 | USB<space>0`.

The original code uses `QString::remove` which removes **all** the occurrences of `0` from the adapter name. The result is `EMU 44 | USB` and its mismatch with the real adapter name causes the firmware update to fail.

The proposed change removes the final `idx` only if the adapter name given by `RtMidi` ends with it. It's a little bit better but just enough to perform the firmware update.